### PR TITLE
Accommodate relocation of deprecated `cet_make()` definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,10 @@ endif()
 
 cet_register_export_set(SET_NAME artdaq_mfextensions NAMESPACE artdaq_mfextensions)
 
+if (NOT COMMAND cet_make)
+  include(compat/CetMakeCommand) # Legacy cet_make()
+endif()
+
 # Configuration Files
 add_subdirectory(fcl)
 


### PR DESCRIPTION
`cet_make()` relegated to `compat/CetMakeCommand.cmake` in Cetmodules 3.23.00.
